### PR TITLE
feat: Add k8s_events receiver

### DIFF
--- a/base/agent_cluster.yaml
+++ b/base/agent_cluster.yaml
@@ -11,6 +11,8 @@ spec:
       k8s_cluster:
         auth_type: serviceAccount
         collection_interval: 60s
+
+      k8s_events:
     
     processors:
       # resource attributes will be used to map the metrics
@@ -123,6 +125,13 @@ spec:
           processors:
             - resource
             - resourceattributetransposer
+            - batch
+          exporters:
+            - otlp
+        logs:
+          receivers:
+            - k8s_events
+          processors:
             - batch
           exporters:
             - otlp


### PR DESCRIPTION
Added the k8sevents receiver to the cluster collector. Added logs pipeline with batching. The output sends to the GCP "gateway" collector(s) via OTLP, which then forwards them to Cloud Logging.

![Screenshot from 2022-04-20 13-31-25](https://user-images.githubusercontent.com/23043836/164289078-6ee095e3-c1ed-4666-920c-c30d6ff60362.png)
