### PR TITLE
Observiq collector 1.2.0. Google refactor.

### DIFF
--- a/base/agent_cluster.yaml
+++ b/base/agent_cluster.yaml
@@ -15,90 +15,6 @@ spec:
       k8s_events:
     
     processors:
-      # resource attributes will be used to map the metrics
-      # to Google Monitored Resource type 'k8s_cluster'
-      # https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
-      #
-      resource:
-        attributes:
-        # Overwrite receiver's attribute, it is probably empty
-        # because the receiver cannot detect the cluster name (clusters do not have "names").
-        - key: k8s.cluster.name
-          value: poc
-          action: upsert
-        # Must map to a GCP region or zone even if running outside of Google Cloud. This is a hard
-        # limitation of the monitored resource types.
-        - key: k8s.cluster.location
-          value: us-east1
-          action: upsert
-
-      # Preserve important resource atributes by copying them
-      # to the metrics labels, as Google exporter will strip
-      # them in favor of the monitored resource type.
-      # 
-      # Note: UID's are not being preserved, resource names should
-      # be good enough when filtering by cluter / node / etc. 
-      #
-      # Note: Some of these fields will be set using the Google exporter's
-      # resource mappings, however, we still want to set them here for
-      # metrics that do not map to the resource "k8s_container" but still
-      # require labels such as 'pod_name' in order to be unique.
-      resourceattributetransposer:
-        operations:
-        # Cluster
-        #
-        - from: k8s.cluster.name
-          to: cluster_name
-
-        # Node
-        #
-        - from: k8s.node.name
-          to: node_name
-
-        # Namespace
-        #
-        # TODO: k8s.namespace.name does not show up, but uid does. Bug?
-        - from: k8s.namespace.name
-          to: namespace_name
-        - from: k8s.namespace.uid
-          to: namespace_uid
-
-        # Daemonset
-        #
-        - from: k8s.daemonset.name
-          to: daemonset
-
-        # Deployment
-        #
-        - from: k8s.deployment.name
-          to: deployment
-
-        # Statefulset
-        #
-        - from: k8s.statefulset.name
-          to: statefulset
-
-        # Replicaset
-        #
-        - from: k8s.replicaset.name
-          to: replicaset
-
-        # Pod
-        #
-        - from: k8s.pod.name
-          to: pod_name
-        - from: pod_phase
-          to: phase
-
-        # Container
-        #
-        - from: k8s.container.name
-          to: container_name
-        - from: container.image.name
-          to: image
-        - from: container.image.tag
-          to: tag
-
       batch:
         send_batch_max_size: 1000
         send_batch_size: 1000
@@ -123,8 +39,6 @@ spec:
           receivers:
             - k8s_cluster
           processors:
-            - resource
-            - resourceattributetransposer
             - batch
           exporters:
             - otlp
@@ -136,16 +50,13 @@ spec:
           exporters:
             - otlp
 
-  image: observiq/observiq-otel-collector:1.1.0
+  image: observiq/observiq-otel-collector:1.2.0
   serviceAccount: observiq-otel-collector
   resources:
     requests:
       memory: 100Mi
       cpu: 100m
   volumes:
-    - name: gcp-credentials
-      secret:
-        secretName: gcp-credentials
     - name: storage
       persistentVolumeClaim:
         claimName: default-volume-observiq-cluster-collector-0

--- a/base/agent_node.yaml
+++ b/base/agent_node.yaml
@@ -30,7 +30,7 @@ spec:
             regex: '^(?P<pod_name>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?P<namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[a-z0-9]{64})\.log$$'
             parse_from: attributes["log.file.name"]
 
-      kubeletstats/node:
+      kubeletstats:
         auth_type: serviceAccount
         collection_interval: 60s
         insecure_skip_verify: true
@@ -38,70 +38,10 @@ spec:
           auth_type: serviceAccount
         metric_groups:
         - node
-
-      kubeletstats/pod:
-        auth_type: serviceAccount
-        collection_interval: 60s
-        insecure_skip_verify: true
-        k8s_api_config:
-          auth_type: serviceAccount
-        metric_groups:
         - pod
-
-      kubeletstats/container:
-        auth_type: serviceAccount
-        collection_interval: 60s
-        insecure_skip_verify: true
-        k8s_api_config:
-          auth_type: serviceAccount
-        metric_groups:
         - container
 
     processors:
-      # resource attributes will be used to map the metrics
-      # to Google Monitored Resource type 'k8s_node'
-      # https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
-      #
-      # opencensus.resourcetype is not set by default, unlike the cluster metrics receiver.
-      # it is required for mapping from opencensus.resourcetype(node) to Google type "k8s_node".
-      resource/node:
-        attributes:
-          - key: opencensus.resourcetype
-            value: node
-            action: upsert
-      resource/pod:
-        attributes:
-          - key: opencensus.resourcetype
-            value: pod
-            action: upsert      
-      resource/container:
-        attributes:
-          - key: opencensus.resourcetype
-            value: container
-            action: upsert
-      resource/all:
-        attributes:
-          - key: k8s.node.name
-            value: "${K8S_NODE_NAME}"
-            action: upsert
-          - key: k8s.cluster.name
-            value: poc
-            action: upsert
-          # Must map to a GCP region or zone even if running outside of Google Cloud. This is a hard
-          # limitation of the monitored resource types.
-          - key: k8s.cluster.location
-            value: us-east1
-            action: upsert
-
-      # Preserve important resource atributes by copying them
-      # to the metrics labels, as Google exporter will strip
-      # them in favor of the monitored resource type.
-      # 
-      resourceattributetransposer/addnodename:
-        operations:
-          - from: k8s.node.name
-            to: node_name
-
       batch:
         send_batch_max_size: 1000
         send_batch_size: 1000
@@ -121,32 +61,10 @@ spec:
       extensions:
         - file_storage
       pipelines:
-        metrics/node:
+        metrics:
           receivers:
-            - kubeletstats/node
+            - kubeletstats
           processors:
-            - resource/all
-            - resource/node
-            - batch
-          exporters:
-            - otlp
-        metrics/pod:
-          receivers:
-            - kubeletstats/pod
-          processors:
-            - resource/all
-            - resource/pod
-            - resourceattributetransposer/addnodename
-            - batch
-          exporters:
-            - otlp
-        metrics/container:
-          receivers:
-            - kubeletstats/container
-          processors:
-            - resource/all
-            - resource/container
-            - resourceattributetransposer/addnodename
             - batch
           exporters:
             - otlp
@@ -158,7 +76,7 @@ spec:
           exporters:
             - otlp
 
-  image: observiq/observiq-otel-collector:1.1.0
+  image: observiq/observiq-otel-collector:1.2.0
   serviceAccount: observiq-otel-collector
   resources:
     requests:

--- a/base/agent_redis.yaml
+++ b/base/agent_redis.yaml
@@ -12,19 +12,11 @@ spec:
         collection_interval: 60s
 
     processors:
-      # resource attributes will be used to map the metrics
-      # to Google Monitored Resource type 'k8s_node'
-      # https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
+      # Add k8s metadata to redis metrics
       resource:
         attributes:
-        - key: opencensus.resourcetype
-          value: pod
-          action: upsert  
         - key: k8s.cluster.name
           value: poc
-          action: upsert
-        - key: k8s.cluster.location
-          value: us-east1
           action: upsert
         - key: k8s.namespace.name
           value: "${K8S_NAMESPACE}"
@@ -35,13 +27,6 @@ spec:
         - key: k8s.node.name
           value: "${K8S_NODE_NAME}"
           action: upsert
-
-      resourceattributetransposer:
-        operations:
-          # Node name is useful when troubleshooting pods / containers. We must copy it here
-          # because Google will strip it away as it is not part of the monitored resource type.
-          - from: k8s.node.name
-            to: node_name
 
     exporters:
       otlp:
@@ -56,11 +41,10 @@ spec:
             - redis
           processors:
             - resource
-            - resourceattributetransposer
           exporters:
             - otlp
 
-  image: observiq/observiq-otel-collector:1.1.0
+  image: observiq/observiq-otel-collector:1.2.0
   resources:
     requests:
       memory: 50Mi

--- a/base/exporters/googlecloud/agent_gateway.yaml
+++ b/base/exporters/googlecloud/agent_gateway.yaml
@@ -91,7 +91,6 @@ spec:
             - prefix: container
 
       logging:
-        #loglevel: debug
 
     extensions:
       health_check:
@@ -102,9 +101,10 @@ spec:
       pipelines:
         # Pipeline for collectors own metrics
         #
+        # TODO(jsirianni): Does not work with gcp, gives duplicate label key error.
         # metrics/collector:
-        #   receivers:
-        #     - prometheus/collector
+        #   #receivers:
+        #   #  - prometheus/collector
         #   processors:
         #     - resource/collector
         #     - resource/all
@@ -130,7 +130,7 @@ spec:
           processors:
             - batch/logs
           exporters:
-            #- logging
+            - logging
             - googlecloud
 
   image: observiq/observiq-otel-collector:1.2.0

--- a/base/exporters/googlecloud/agent_gateway.yaml
+++ b/base/exporters/googlecloud/agent_gateway.yaml
@@ -40,29 +40,37 @@ spec:
             endpoint: 0.0.0.0:4317
 
     processors:
-      # resource attributes will be used to map the metrics
+      # Resource attributes will be used to map the metrics
       # to Google Monitored Resource type 'k8s_node'
       # https://cloud.google.com/logging/docs/api/v2/resource-list#resource-types
       resource/collector:
         attributes:
-        - key: opencensus.resourcetype
-          value: pod
-          action: upsert
-        - key: k8s.cluster.name
-          value: poc
-          action: upsert
-        - key: k8s.cluster.location
-          value: us-east1
-          action: upsert
         - key: k8s.namespace.name
           value: "${K8S_NAMESPACE}"
-          action: upsert
+          action: insert
         - key: k8s.pod.name
           value: "${K8S_POD_NAME}"
-          action: upsert
+          action: insert
         - key: k8s.node.name
           value: "${K8S_NODE_NAME}"
-          action: upsert
+          action: insert
+
+      # Google requires k8s.cluster.name, cloud.region, cloud.availability_zone and
+      # cloud.platform in order to map to container, pod, node, and cluster resource types.
+      resource/all:
+        attributes:
+        - key: k8s.cluster.name
+          value: poc
+          action: insert
+        - key: cloud.region
+          value: us-east1
+          action: insert
+        - key: cloud.availability_zone
+          value: us-east1-b
+          action: insert
+        - key: cloud.platform
+          value: gcp_kubernetes_engine
+          action: insert
 
       batch/metrics:
         send_batch_max_size: 200
@@ -75,66 +83,15 @@ spec:
         timeout: 5s
     
     exporters:
-      googlecloud/metrics:
-        resource_mappings:
-          # K8s cluster mapping
-          #
-          - source_type: k8s
-            target_type: k8s_cluster
-            label_mappings:
-              - source_key: k8s.cluster.name
-                target_key: cluster_name
-              - source_key: k8s.cluster.location
-                target_key: location
-          
-          # K8s node mapping
-          #
-          - source_type: node
-            target_type: k8s_node
-            label_mappings:
-              - source_key: k8s.cluster.name
-                target_key: cluster_name
-              - source_key: k8s.cluster.location
-                target_key: location
-              - source_key: k8s.node.name
-                target_key: node_name
-
-          # K8s pod mapping
-          #
-          - source_type: pod
-            target_type: k8s_pod
-            label_mappings:
-              - source_key: k8s.pod.name
-                target_key: pod_name
-              - source_key: k8s.namespace.name
-                target_key: namespace_name
-              - source_key: k8s.cluster.name
-                target_key: cluster_name
-              - source_key: k8s.cluster.location
-                target_key: location
-
-          # K8s container mapping
-          #
-          - source_type: container
-            target_type: k8s_container
-            label_mappings:
-              - source_key: k8s.cluster.name
-                target_key: cluster_name
-              - source_key: k8s.cluster.location
-                target_key: location
-              - source_key: k8s.namespace.name
-                target_key: namespace_name
-              - source_key: k8s.pod.name
-                target_key: pod_name
-              - source_key: k8s.container.name
-                target_key: container_name
-
-      googlecloud/logs:
-        # TODO: Project is not required, but there is a bug for logs where a missing
-        # project ID causes logs to fail.
-        project: otel-k8s-devel-352720
+      googlecloud:
+        metric:
+          resource_filters:
+            - prefix: k8s
+            - prefix: cloud
+            - prefix: container
 
       logging:
+        #loglevel: debug
 
     extensions:
       health_check:
@@ -145,24 +102,26 @@ spec:
       pipelines:
         # Pipeline for collectors own metrics
         #
-        metrics/collector:
-          receivers:
-            - prometheus/collector
-          processors:
-            - resource/collector
-          exporters:
-            - logging
-            - googlecloud/metrics
+        # metrics/collector:
+        #   receivers:
+        #     - prometheus/collector
+        #   processors:
+        #     - resource/collector
+        #     - resource/all
+        #   exporters:
+        #     - logging
+        #     - googlecloud
         # Pipeline for ingested metrics
         #
         metrics/ingest:
           receivers:
             - otlp
           processors:
+            - resource/all
             - batch/metrics
           exporters:
             - logging
-            - googlecloud/metrics
+            - googlecloud
         # Pipeline for ingested logs
         #
         logs:
@@ -171,10 +130,10 @@ spec:
           processors:
             - batch/logs
           exporters:
-            - logging
-            - googlecloud/logs
+            #- logging
+            - googlecloud
 
-  image: observiq/observiq-otel-collector:1.1.0
+  image: observiq/observiq-otel-collector:1.2.0
   resources:
     requests:
       memory: 100Mi

--- a/base/exporters/logging/agent_gateway.yaml
+++ b/base/exporters/logging/agent_gateway.yaml
@@ -54,7 +54,7 @@ spec:
           exporters:
             - logging
 
-  image: observiq/observiq-otel-collector:1.1.0
+  image: observiq/observiq-otel-collector:1.2.0
   replicas: 1
   maxReplicas: 1
   resources:

--- a/base/exporters/newrelic/agent_gateway.yaml
+++ b/base/exporters/newrelic/agent_gateway.yaml
@@ -49,9 +49,6 @@ spec:
         - key: k8s.cluster.name
           value: poc
           action: upsert
-        - key: k8s.cluster.location
-          value: us-east1
-          action: upsert
         - key: k8s.namespace.name
           value: "${K8S_NAMESPACE}"
           action: upsert
@@ -120,7 +117,7 @@ spec:
             - logging
             - otlp/newrelic
 
-  image: observiq/observiq-otel-collector:1.1.0
+  image: observiq/observiq-otel-collector:1.2.0
   resources:
     requests:
       memory: 100Mi

--- a/environments/googlecloud/agent_gateway.yaml
+++ b/environments/googlecloud/agent_gateway.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   # setting 'replicas' w/ 'maxReplicas' will configure an autoscaler with
   # min 2 and max 5 replicas.
-  replicas: 1
-  maxReplicas: 1
+  replicas: 2
+  maxReplicas: 5

--- a/environments/googlecloud/agent_gateway.yaml
+++ b/environments/googlecloud/agent_gateway.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   # setting 'replicas' w/ 'maxReplicas' will configure an autoscaler with
   # min 2 and max 5 replicas.
-  replicas: 2
-  maxReplicas: 5
+  replicas: 1
+  maxReplicas: 1


### PR DESCRIPTION
oiq collector 1.2.0 uses the latest Google exporter, which changes how things are configured. We no longer need to map resources on our own.