### PR TITLE
fix: K8sattributes and kubestats

### DIFF
--- a/base/agent_cluster.yaml
+++ b/base/agent_cluster.yaml
@@ -69,7 +69,7 @@ spec:
           exporters:
             - otlp
 
-  image: observiq/observiq-otel-collector:1.3.0
+  image: observiq/observiq-otel-collector:1.4.0
   serviceAccount: observiq-otel-collector
   resources:
     requests:
@@ -82,8 +82,5 @@ spec:
   volumeMounts:
     - mountPath: /var/lib/observiq/otelcol/cluster
       name: storage
-  env:
-    - name: K8S_CLUSTER
-      value: "cluster"
   podSecurityContext:
     runAsUser: 0

--- a/base/agent_node.yaml
+++ b/base/agent_node.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: default
 spec:
   mode: daemonset
+  hostNetwork: true
   config: |
     receivers:
       journald/kubelet:
@@ -201,7 +202,7 @@ spec:
           exporters:
             - otlp
 
-  image: observiq/observiq-otel-collector:1.3.0
+  image: observiq/observiq-otel-collector:1.4.0
   serviceAccount: observiq-otel-collector
   resources:
     requests:
@@ -225,13 +226,5 @@ spec:
     - mountPath: /var/lib/observiq/otelcol/node
       name: storage
       readOnly: false
-  env:
-    - name: K8S_CLUSTER
-      value: "cluster"
-    - name: KUBE_NODE_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: spec.nodeName
   podSecurityContext:
     runAsUser: 0

--- a/base/agent_redis.yaml
+++ b/base/agent_redis.yaml
@@ -45,23 +45,8 @@ spec:
           exporters:
             - otlp
 
-  image: observiq/observiq-otel-collector:1.3.0
+  image: observiq/observiq-otel-collector:1.4.0
   resources:
     requests:
       memory: 50Mi
       cpu: 50m
-  env:
-    - name: K8S_NODE_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    - name: K8S_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: K8S_POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-    - name: K8S_CLUSTER
-      value: "cluster"

--- a/base/exporters/googlecloud/agent_gateway.yaml
+++ b/base/exporters/googlecloud/agent_gateway.yaml
@@ -55,6 +55,47 @@ spec:
           value: gcp_kubernetes_engine
           action: insert
 
+      # Logs: Preserve resource labels that are discarded after mapping to
+      # google monitored resource type. The following are preserved by
+      # google exporter log pipelines:
+      #     -> k8s.cluster.name: STRING(google-poc)
+      #     -> k8s.container.name: STRING(otc-container)
+      #     -> k8s.namespace.name: STRING(default)
+      #     -> k8s.pod.name: STRING(observiq-node-collector-46r2h)
+      # The following should be moved to labels
+      #     -> k8s.deployment.name: STRING(observiq-node)
+      #     -> k8s.node.name: STRING(minikube)
+      #     -> k8s.pod.start_time: STRING(2022-07-18 19:02:31 +0000 UTC)
+      #     -> k8s.pod.uid: STRING(82aa9f33-f049-4d6f-b329-a8bf3ef4d819)
+      #     -> container.image.name: STRING(bmedora/observiq-otel-collector-amd64)
+      #     -> container.image.tag: STRING(k8s-dev.0)
+      logstransform/k8spodlabels:
+        operators:
+          - type: move
+            if: resource["k8s.deployment.name"] != nil
+            from: resource["k8s.deployment.name"]
+            to: attributes["k8s.deployment.name"]
+          - type: move
+            if: resource["k8s.node.name"] != nil
+            from: resource["k8s.node.name"]
+            to: attributes["k8s.node.name"]
+          - type: move
+            if: resource["k8s.pod.start_time"] != nil
+            from: resource["k8s.pod.start_time"]
+            to: attributes["k8s.pod.start_time"]
+          - type: move
+            if: resource["k8s.pod.uid"] != nil
+            from: resource["k8s.pod.uid"]
+            to: attributes["k8s.pod.uid"]
+          - type: move
+            if: resource["container.image.name"] != nil
+            from: resource["container.image.name"]
+            to: attributes["container.image.name"]
+          - type: move
+            if: resource["container.image.tag"] != nil
+            from: resource["container.image.tag"]
+            to: attributes["container.image.tag"]
+
       batch/metrics:
         send_batch_max_size: 200
         send_batch_size: 200
@@ -99,12 +140,13 @@ spec:
           processors:
             - resourcedetection
             - resource/all
+            - logstransform/k8spodlabels
             - batch/logs
           exporters:
             - logging
             - googlecloud
 
-  image: observiq/observiq-otel-collector:1.3.0
+  image: observiq/observiq-otel-collector:1.4.0
   resources:
     requests:
       memory: 100Mi

--- a/base/exporters/logging/agent_gateway.yaml
+++ b/base/exporters/logging/agent_gateway.yaml
@@ -55,7 +55,7 @@ spec:
           exporters:
             - logging
 
-  image: observiq/observiq-otel-collector:1.3.0
+  image: observiq/observiq-otel-collector:1.4.0
   replicas: 1
   maxReplicas: 1
   resources:

--- a/base/exporters/newrelic/agent_gateway.yaml
+++ b/base/exporters/newrelic/agent_gateway.yaml
@@ -86,7 +86,7 @@ spec:
             - logging
             - otlp/newrelic
 
-  image: observiq/observiq-otel-collector:1.3.0
+  image: observiq/observiq-otel-collector:1.4.0
   resources:
     requests:
       memory: 100Mi

--- a/base/exporters/otlp/agent_gateway.yaml
+++ b/base/exporters/otlp/agent_gateway.yaml
@@ -25,7 +25,7 @@ metadata:
     app: observiq-gateway
 spec:
   mode: deployment
-  image: observiq/observiq-otel-collector:1.3.0
+  image: observiq/observiq-otel-collector:1.4.0
   resources:
     requests:
       memory: 100Mi

--- a/environments/googlecloud/agent.yaml
+++ b/environments/googlecloud/agent.yaml
@@ -23,6 +23,11 @@ spec:
   env:
     - name: K8S_CLUSTER
       value: "google-poc"
+    - name: KUBE_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
@@ -33,3 +38,15 @@ spec:
   env:
     - name: K8S_CLUSTER
       value: "google-poc"
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name

--- a/environments/newrelic/agent.yaml
+++ b/environments/newrelic/agent.yaml
@@ -23,6 +23,11 @@ spec:
   env:
     - name: K8S_CLUSTER
       value: "newrelic-poc"
+    - name: KUBE_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
@@ -33,3 +38,15 @@ spec:
   env:
     - name: K8S_CLUSTER
       value: "newrelic-poc"
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name

--- a/environments/otlp/agent.yaml
+++ b/environments/otlp/agent.yaml
@@ -23,6 +23,11 @@ spec:
   env:
     - name: K8S_CLUSTER
       value: "otlp-poc"
+    - name: KUBE_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
@@ -33,3 +38,15 @@ spec:
   env:
     - name: K8S_CLUSTER
       value: "otlp-poc"
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name


### PR DESCRIPTION
- Fixed k8sattributes by moving all env configuration to each environment. Previously, KUBE_NODE_NAME (and other variables) were being replaced by Kustomize.
- Use image v1.4.0 which fixes k8sattributes
- Use hostNetwork for node collector, otherwise connections to the kubelet API fail
- For Google logging, copy k8s pod resources to labels to prevent them from being stripped out when mapped to Google monitored resource type k8s_pod.

Metrics:

![Screenshot from 2022-07-18 15-37-28](https://user-images.githubusercontent.com/23043836/179603403-4668d493-ad10-4c15-91d8-9bcd09b758fa.png)

Logs:

![Screenshot from 2022-07-18 15-37-54](https://user-images.githubusercontent.com/23043836/179603475-c84e4be3-4834-4e3d-ac16-cf05bc498025.png)
